### PR TITLE
Modifies requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 einops
 matplotlib
-numpy
+numpy==1.26.4
 pandas
 torch==2.3.0
 pytorch-lightning==2.3.0
@@ -8,5 +8,6 @@ PyYAML
 scikit-learn
 scipy
 statsmodels==0.14.0
+torchtune
 wandb
 x-transformers==1.30.22


### PR DESCRIPTION
The latest version of numpy 2.0.0 is not compatible with this codebase. I've specified the previous version before this is installed 1.26.4 which is compatible. Also, torchtune is added as a requirement which was missing. Refers to issue: #4 